### PR TITLE
Update doc/api/cli.md, add cipher DEFAULT@SECLEVEL=0

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1649,7 +1649,8 @@ added:
 -->
 
 Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1'. Use for compatibility with
-old TLS clients or servers.
+old TLS clients or servers. To support TLSv1 on the server, you will also need to
+set `--tls-cipher-list=DEFAULT@SECLEVEL=0`.
 
 ### `--tls-min-v1.1`
 
@@ -1660,7 +1661,8 @@ added:
 -->
 
 Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.1'. Use for compatibility
-with old TLS clients or servers.
+with old TLS clients or servers. To support TLSv1.1 on the server, you will also need to
+set `--tls-cipher-list=DEFAULT@SECLEVEL=0`.
 
 ### `--tls-min-v1.2`
 


### PR DESCRIPTION
For TLSv1 to work on the server you need to pass both `--tls-min-v1.0` and `--tls-cipher-list=DEFAULT@SECLEVEL=0` (same for TLSv1.1).
